### PR TITLE
Implement new Nav feature.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,10 @@ sass:
 gems:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
+  - jekyll-seo-tag
+  - jekyll-compose
+  - jekyll-toc
+  - jekyll-coffeescript
 
 # Exclude these files from your production _site
 exclude:

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -14,12 +14,13 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
     <link href='http://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
 
+    {% seo %}
   </head>
 
   <body>
-    
-    
-    <div class="intro-header">    
+
+
+    <div class="intro-header">
       <div class="container">
         <div class="post-heading">
             <h1>{{page.title}}</h1>
@@ -28,10 +29,10 @@
             <a href="{{ site.baseurl }}/"> { Return to Blog }</a>
             </span>
         </div>
-            
+
       </div>
     </div>
-    
+
 
     <div id="main" role="main" class="container">
       {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,11 +3,12 @@ layout: blog
 ---
 
 <article class="post">
+  <script src="/scripts/nav.js"></script>
  <div class="space-extra-small">
  </div>
 
-  <div class="entry">
-    {{ content }}
+  <div id="currentEntry" class="entry">
+    {{ content | toc }}
   </div>
 
   {% include disqus.html %}

--- a/_posts/2016-06-20-meta-blog.md
+++ b/_posts/2016-06-20-meta-blog.md
@@ -9,7 +9,8 @@ author: Jphoenx
 
 First things first. How do you go about making a blog.
 
-<h2> Well at a high level the most important things are 3 fold: </h2>
+<h2>At a high level in order to make a blog you need 3 things in order to be
+successful:</h2>
 
 1. **Consistency**
 (choose a schedule and stick to it). Hate schedules? Yeah... I'm in a similar boat.

--- a/_posts/2016-09-01-how-to-program-in-java-using-static-and-final.md
+++ b/_posts/2016-09-01-how-to-program-in-java-using-static-and-final.md
@@ -2,11 +2,12 @@
 layout: post
 title: How to Program in Java using Static and Final
 author: Jphoenx
+toc: true
 ---
 
 AKA: Functional Java
 
-## <a name="tl;dr"></a>TL;DR
+## TL;DR
 
 1. Use final on your data structures to lock down your data
   * Make copies of things as you go to change data.
@@ -17,17 +18,13 @@ AKA: Functional Java
 3. If using both and you want to change the underlying data structure.
   * The return type is a new updated version of the object in question.
 
-* [TL;DR](#tl;dr)
-* [See example](#example)
-* [Learn about final](#final)
-* [Learn about static](#static)
-* [Skip ahead to the better way](#functionalJava "Functional Java")
+<h4 class="nav-anchor">See example</h4>
 
-## <a name="example"></a>Basic Request Example
+## Basic Example
 
 To use an example from an HTTP Server (a pretty common example in Java-land):
 
-```java
+{% highlight java %}
 
 class Request {
     private byte[] header;
@@ -51,12 +48,12 @@ class Request {
     }
 }
 
-```
+{% endhighlight %}
 
 Now if we wanted to use the isValid() method on Request we would first have to
 create a new one and then we could use it.
 
-```java
+{% highlight java %}
 
 byte[] header = "GET /images HTTP/1.1\r\n\r\n".getBytes();
 byte[] body = "".getBytes();
@@ -64,20 +61,15 @@ Request request = new Request(header, body);
 if (!request.isValid()) {
     // DO WORK WITH REQUEST
 }
-
-```
+{% endhighlight %}
 
 This is fine... and I've coded working systems using this very approach.
 
 But there is a better way.
 
-* [TL;DR](#tl;dr)
-* [See example](#example)
-* [Learn about final](#final)
-* [Learn about static](#static)
-* [Skip ahead to the better way](#functionalJava "Functional Java")
+<h4 class="nav-anchor">Learn about Final</h4>
 
-## <a name="final"></a>What does final mean?
+## What does final mean?
 
 Final means that a value cannot be changed after you **finish** making it.
 
@@ -85,7 +77,7 @@ Back to our Request example.
 
 NOTE that the two fields at the top now have **final** in front of them.
 
-```java
+{% highlight java %}
 
 class Request {
     private final byte[] header;
@@ -109,7 +101,7 @@ class Request {
     }
 }
 
-```
+{% endhighlight %}
 
 The way that this works is that header and body get assigned inside of the
 constructor and then they cannot be mutated at all.
@@ -119,13 +111,13 @@ changing later... say for concurrency, testing, or your sanity.
 
 Ok... so the way to construct a basic Request has not changed yet:
 
-```java
+{% highlight java %}
 
 byte[] header = "POST /users HTTP/1.1\r\n\r\n".getBytes();
 byte[] body = "".getBytes();
 Request currentRequest = new Request(header, body);
 
-```
+{% endhighlight %}
 
 But oh no... we forgot to parse the body in that request... and now it is
 final and we can't change it...
@@ -133,18 +125,18 @@ final and we can't change it...
 Well if you ever wanted to change the value of one of those. You would create a
 new object like so:
 
-```java
+{% highlight java %}
 
 byte[] currentHeader = currentRequest.getHeader();
 byte[] currentBody = currentRequest.getBody();
 byte[] updatedBody = combine(currentBody, "data: pie".getBytes());
 Request updatedRequest = new Request(currentHeader, updatedBody);
 
-```
+{% endhighlight %}
 
 And then the combine method:
 
-```java
+{% highlight java %}
 
 private byte[] combine(byte[] original, byte[] addend) throws IOException {
     ByteArrayOutputStream combined = new ByteArrayOutputStream();
@@ -153,17 +145,11 @@ private byte[] combine(byte[] original, byte[] addend) throws IOException {
     return combined.toByteArray();
 }
 
-```
+{% endhighlight %}
 
+<h4 class="nav-anchor">Learn about Static</h4>
 
-* [TL;DR](#tl;dr)
-* [See example](#example)
-* [Learn about final](#final)
-* [Learn about static](#static)
-* [Skip ahead to the better way](#functionalJava "Functional Java")
-
-
-## <a name="static"></a>What does static mean?
+## What does static mean?
 
 Static denotes that a particular field or method should be a class level field
 or method.
@@ -173,7 +159,7 @@ Let's look at our example again.
 NOTE that the isValid method is now static AND takes an argument of type
 Request.
 
-```java
+{% highlight java %}
 
 class Request {
     private byte[] header;
@@ -197,12 +183,12 @@ class Request {
     }
 }
 
-```
+{% endhighlight %}
 
 Since isValid now takes in a request object we have to change the way we
 call it slightly:
 
-```java
+{% highlight java %}
 
 byte[] header = "GET /images HTTP/1.1\r\n\r\n".getBytes();
 byte[] body = "".getBytes();
@@ -211,7 +197,7 @@ if (!Request.isValid(request)) {
     // DO WORK WITH REQUEST
 }
 
-```
+{% endhighlight %}
 
 The static part makes it so that we call isValid directly on the Request class.
 
@@ -219,17 +205,13 @@ And because its being called directly on the Request class... in order for it
 to know what request we are talking about... we have to pass it a request
 directly.
 
-* [TL;DR](#tl;dr)
-* [See example](#example)
-* [Learn about final](#final)
-* [Learn about static](#static)
-* [Skip ahead to the better way](#functionalJava "Functional Java")
+<h4 class="nav-anchor">Skip ahead to better way</h4>
 
-## <a name="functionalJava"></a>Functional Java
+## Functional Java
 
 Completed code using both approaches together:
 
-```java
+{% highlight java %}
 
 class Request {
     private final byte[] header;
@@ -253,11 +235,11 @@ class Request {
     }
 }
 
-```
+{% endhighlight %}
 
 And the invoking code:
 
-```java
+{% highlight java %}
 
 byte[] header = "GET /images HTTP/1.1\r\n\r\n".getBytes();
 byte[] body = "".getBytes();
@@ -266,7 +248,7 @@ if (!Request.isValid(request)) {
     // DO WORK WITH REQUEST
 }
 
-```
+{% endhighlight %}
 
 ### Lock down your data structures using final.
 
@@ -283,7 +265,7 @@ new copy of that object and return it.
 
 MOAR EXAMPLES
 
-```java
+{% highlight java %}
 
 public static Map parseHeaders(Request request) {
     // GO THROUGH THE REQUEST HEADER AND PARSE OUT THINGS LIKE
@@ -297,10 +279,4 @@ public static Request addBodyContent(Request request, byte[] newContent) {
     return new Request(request.getHeader(), updatedBody);
 }
 
-```
-
-* [TL;DR](#tl;dr)
-* [See example](#example)
-* [Learn about final](#final)
-* [Learn about static](#static)
-* [Skip ahead to the better way](#functionalJava "Functional Java")
+{% endhighlight %}

--- a/_posts/2016-09-09-art-of-practicing.md
+++ b/_posts/2016-09-09-art-of-practicing.md
@@ -2,7 +2,10 @@
 layout: post
 title: The art of practicing 1
 author: Jphoenx
+toc: true
 ---
+
+<h4 class="nav-anchor">Chunking</h4>
 
 ## Chunking
 
@@ -43,6 +46,8 @@ This is the dream. You no longer have to think about the domain at all you can j
 If you are reading this blog... then its safe to assume that you know how to go from Bucket A to Bucket B...
 sure this process can *always* be optimized... but the real question is:
 
+<h4 class="nav-anchor">Pattern Recognition</h4>
+
 ## Pattern recognition
 
 In [the Art of Learning](https://www.amazon.com/Art-Learning-Journey-Optimal-Performance/dp/B00JE2WEEK),
@@ -68,6 +73,8 @@ The grandmasters had more patterns chunked than the experts... and when they cou
 perform the task faster than the experts.
 
 But when it was just random positions their was no difference between the two.
+
+<h4 class="nav-anchor">How do you go from Bucket B to Bucket C?</h4>
 
 ## How do you go from Bucket B to Bucket C?
 

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -1,0 +1,45 @@
+.section-nav {
+  padding-left: 0;
+
+  li {
+    list-style: none;
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: white;
+    margin: 0;
+    border-right: 1px solid gray;
+    font-size: 11pt;
+  }
+}
+
+.fixed-nav {
+  position: fixed;
+  top: 0;
+  background-color: white;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+// Only display H4's in nav.
+.toc-entry.toc-h4
+{}
+.toc-entry.toc-h1,
+.toc-entry.toc-h2,
+.toc-entry.toc-h3,
+.toc-entry.toc-h5,
+.toc-entry.toc-h6
+{
+  display: none;
+}
+
+// Make nav-anchor (which should be on H4 elements) be invisible.
+.nav-anchor {
+  visibility: hidden;
+}
+
+.nav-padding {
+  padding-top: 45px;
+}
+
+

--- a/scripts/nav.coffee
+++ b/scripts/nav.coffee
@@ -1,0 +1,28 @@
+---
+---
+
+window.addEventListener('scroll', (ev) ->
+  introContainerDistance = document.getElementsByClassName("intro-header")[0].clientHeight
+  smallSpaceDistance = document.getElementsByClassName("space-extra-small")[0].clientHeight
+  navContainerDistance = smallSpaceDistance + introContainerDistance
+  distanceToTop = window.pageYOffset
+  console.log("nav: " + navContainerDistance)
+  console.log("distance to top: " + distanceToTop)
+  toggleElements(distanceToTop, navContainerDistance)
+)
+
+toggleElements = (distanceToTop, navContainerDistance) ->
+  nav = document.getElementsByClassName("section-nav")[0]
+  entry = document.getElementById("currentEntry")
+  if distanceToTop >= navContainerDistance
+    addClassToElement(nav, 'fixed-nav')
+    addClassToElement(entry, 'nav-padding')
+  else
+    removeClassFromElement(nav, 'fixed-nav')
+    removeClassFromElement(entry, 'nav-padding')
+
+addClassToElement = (element, classToAdd) ->
+    element.classList.add(classToAdd)
+
+removeClassFromElement = (element, classToRemove) ->
+    element.classList.remove(classToRemove)

--- a/style.scss
+++ b/style.scss
@@ -9,6 +9,7 @@
 @import "variables";
 
 
+
 /**************/
 /* BASE RULES */
 /**************/
@@ -290,3 +291,6 @@ footer {
 
 @import "highlights";
 @import "jekyll-mono";
+
+// JPHoenx addition
+@import "nav";


### PR DESCRIPTION
This PR implements a new Nav Feature.

It uses hidden H4's and the jekyll-toc plugin (along with nav.coffee and nav.scss) to go through and populate a navbar that sticks to the top.

The navbar is only populated with H4's.

And they should always be hidden with the nav-anchor class (for formatting and so that the navtext can be different from the H1-H2 text).
